### PR TITLE
Add Instagram caching and media endpoint

### DIFF
--- a/imx/README.md
+++ b/imx/README.md
@@ -90,6 +90,14 @@ Brands post campaigns via `/backend/campaigns.php`. Influencers view eligible ca
 
 The shared `css/instagram-theme.css` stylesheet gives the interface an Instagram-inspired design. Users can enable dark mode via `css/dark-theme.css` using the new toggle button in each header.
 
+## Profile Editing
+
+Users can now update their username, bio, category and payout details from the new `pages/profile-edit.php` screen. Profile pictures may be uploaded and are stored under `uploads/influencers/` or `uploads/brands/` depending on role.
+
+## Instagram API Caching
+
+To minimise calls to Instagram and improve performance, API requests now use a simple file based cache in the new `cache/` directory. Helper functions in `includes/instagram_api.php` provide profile, insights and top media data with a short TTL. Endpoints can request cached data via `/backend/influencer.php?action=top_media`.
+
 ## Development
 
 To install PHP dependencies, run `composer install` inside this directory. Ensure a MySQL server is available and load `schema.sql` to create tables.

--- a/imx/backend/auth.php
+++ b/imx/backend/auth.php
@@ -3,7 +3,8 @@ require_once 'db.php';
 require_once __DIR__ . '/../includes/csrf.php';
 require_once __DIR__ . '/../includes/jwt_helper.php';
 require_once __DIR__ . '/../includes/env.php';
-session_start();
+require_once __DIR__ . '/../includes/security.php';
+secure_session_start();
 
 function respond($success, $message, $redirect = null, array $extra = []) {
     header('Content-Type: application/json');
@@ -38,13 +39,18 @@ try {
             $email = $_POST['email'] ?? '';
             $password = $_POST['password'] ?? '';
             $role = $_POST['role'] ?? '';
+            $companyName = $_POST['company_name'] ?? '';
+            $website = $_POST['website'] ?? '';
+            $industry = $_POST['industry'] ?? '';
+            $instaHandle = $_POST['instagram_handle'] ?? '';
+            $category = $_POST['category'] ?? '';
 
             if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
                 respond(false, 'Invalid email address.');
             }
 
-            if (strlen($password) < 6) {
-                respond(false, 'Password must be at least 6 characters.');
+            if (strlen($password) < 8) {
+                respond(false, 'Password must be at least 8 characters.');
             }
 
             // Validate role from param, default to brand if invalid
@@ -60,8 +66,14 @@ try {
             }
 
             $password_hash = password_hash($password, PASSWORD_DEFAULT);
-            $stmt = $pdo->prepare("INSERT INTO {$table} (email, password_hash) VALUES (?, ?)");
-            if ($stmt->execute([$email, $password_hash])) {
+            if ($role === 'brand') {
+                $stmt = $pdo->prepare("INSERT INTO brands (email, password_hash, company_name, website, industry) VALUES (?, ?, ?, ?, ?)");
+                $params = [$email, $password_hash, $companyName, $website, $industry];
+            } else {
+                $stmt = $pdo->prepare("INSERT INTO influencers (email, password_hash, instagram_handle, category) VALUES (?, ?, ?, ?)");
+                $params = [$email, $password_hash, $instaHandle, $category];
+            }
+            if ($stmt->execute($params)) {
                 respond(true, 'Registration successful. You can now log in.');
             } else {
                 respond(false, 'Registration failed. Please try again.');
@@ -75,12 +87,14 @@ try {
             }
 
             // Check brand first
-            $stmt = $pdo->prepare('SELECT id, password_hash FROM brands WHERE email = ?');
+            $stmt = $pdo->prepare('SELECT id, password_hash, company_name, email FROM brands WHERE email = ?');
             $stmt->execute([$email]);
             $user = $stmt->fetch();
             if ($user && password_verify($password, $user['password_hash'])) {
                 $_SESSION['user_id'] = $user['id'];
                 $_SESSION['role'] = 'brand';
+                $_SESSION['username'] = $user['company_name'] ?: explode('@', $user['email'])[0];
+                session_regenerate_id(true);
                 $token = create_jwt([
                     'uid' => $user['id'],
                     'role' => 'brand',
@@ -90,12 +104,15 @@ try {
             }
 
             // Then influencer
-            $stmt = $pdo->prepare('SELECT id, password_hash FROM influencers WHERE email = ?');
+            $stmt = $pdo->prepare('SELECT id, password_hash, username, instagram_handle, email FROM influencers WHERE email = ?');
             $stmt->execute([$email]);
             $user = $stmt->fetch();
             if ($user && password_verify($password, $user['password_hash'])) {
                 $_SESSION['user_id'] = $user['id'];
                 $_SESSION['role'] = 'influencer';
+                $uname = $user['username'] ?: ($user['instagram_handle'] ?: explode('@', $user['email'])[0]);
+                $_SESSION['username'] = $uname;
+                session_regenerate_id(true);
                 $token = create_jwt([
                     'uid' => $user['id'],
                     'role' => 'influencer',

--- a/imx/backend/brand.php
+++ b/imx/backend/brand.php
@@ -1,7 +1,7 @@
 <?php
 require_once 'db.php';
-session_start();
-require_once __DIR__ . "/../includes/security.php";
+require_once __DIR__ . '/../includes/security.php';
+secure_session_start();
 
 function respond($success, $data = null, $message = '') {
     header('Content-Type: application/json');
@@ -30,6 +30,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET' && $action === 'profile') {
     $stmt = $pdo->prepare('SELECT id, name AS company_name, email, profile_pic AS logo_url, gstin, industry, website FROM brands WHERE id = ?');
     $stmt->execute([$user_id]);
     $profile = $stmt->fetch();
+    if ($profile && empty($profile['company_name'])) {
+        $profile['company_name'] = explode('@', $profile['email'])[0];
+    }
     if ($profile) {
         respond(true, $profile);
     } else {

--- a/imx/backend/influencer.php
+++ b/imx/backend/influencer.php
@@ -1,8 +1,8 @@
 <?php
 require_once 'db.php';
 require_once __DIR__ . '/../includes/instagram_api.php';
-session_start();
-require_once __DIR__ . "/../includes/security.php";
+require_once __DIR__ . '/../includes/security.php';
+secure_session_start();
 
 function respond($success, $data = null, $message = '') {
     header('Content-Type: application/json');
@@ -29,9 +29,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET' && $action === 'profile' && $role === '
     try {
         // Fetch influencer profile
         $user_id = $_SESSION['user_id'];
-        $stmt = $pdo->prepare('SELECT id, email, username, profile_pic FROM influencers WHERE id = ?');
+        $stmt = $pdo->prepare('SELECT id, email, username, instagram_handle, profile_pic FROM influencers WHERE id = ?');
         $stmt->execute([$user_id]);
         $profile = $stmt->fetch();
+        if ($profile && empty($profile['username'])) {
+            $profile['username'] = $profile['instagram_handle'] ?: explode('@', $profile['email'])[0];
+        }
         if ($profile) {
             respond(true, $profile);
         } else {
@@ -139,6 +142,63 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET' && $action === 'profile' && $role === '
         }
     }
     respond(false, null, 'Unable to refresh profile');
+} elseif ($_SERVER['REQUEST_METHOD'] === 'GET' && $action === 'top_media' && $role === 'influencer') {
+    $tokenStmt = $pdo->prepare('SELECT ig_user_id, access_token FROM instagram_tokens WHERE user_id = ?');
+    $tokenStmt->execute([$_SESSION['user_id']]);
+    $row = $tokenStmt->fetch(PDO::FETCH_ASSOC);
+    if ($row && $row['access_token']) {
+        $media = instagram_get_top_media($row['ig_user_id'], $row['access_token']);
+        if ($media) {
+            respond(true, $media);
+        }
+    }
+    respond(false, null, 'Unable to fetch top media');
+} elseif ($_SERVER['REQUEST_METHOD'] === 'POST' && $action === 'update_profile' && $role === 'influencer') {
+    require_csrf();
+    $user_id = $_SESSION['user_id'];
+    $username = sanitize_text('username');
+    $bio = sanitize_text('bio');
+    $category = sanitize_text('category');
+    $upi_id = sanitize_text('upi_id');
+    $pic_url = null;
+    if (isset($_FILES['profile_pic']) && validate_upload($_FILES['profile_pic'], ['image/jpeg','image/png'])) {
+        $dir = __DIR__ . '/../uploads/influencers/';
+        if (!is_dir($dir)) { mkdir($dir, 0755, true); }
+        $fname = uniqid() . '_' . basename($_FILES['profile_pic']['name']);
+        $target = $dir . $fname;
+        if (move_uploaded_file($_FILES['profile_pic']['tmp_name'], $target)) {
+            $pic_url = '/uploads/influencers/' . $fname;
+        } else {
+            respond(false, null, 'Failed to upload profile picture.');
+        }
+    } elseif (isset($_FILES['profile_pic'])) {
+        respond(false, null, 'Invalid profile picture.');
+    }
+
+    $stmt = $pdo->prepare('SELECT id FROM influencers WHERE id = ?');
+    $stmt->execute([$user_id]);
+    $exists = $stmt->fetch();
+
+    if ($exists) {
+        $sql = 'UPDATE influencers SET username=?, bio=?, category=?, upi_id=?';
+        $params = [$username, $bio, $category, $upi_id];
+        if ($pic_url) { $sql .= ', profile_pic=?'; $params[] = $pic_url; }
+        $sql .= ' WHERE id=?';
+        $params[] = $user_id;
+        $up = $pdo->prepare($sql);
+        if ($up->execute($params)) {
+            respond(true, null, 'Profile updated successfully.');
+        } else {
+            respond(false, null, 'Failed to update profile.');
+        }
+    } else {
+        $stmt = $pdo->prepare('INSERT INTO influencers (id, username, bio, category, upi_id, profile_pic) VALUES (?, ?, ?, ?, ?, ?)');
+        if ($stmt->execute([$user_id, $username, $bio, $category, $upi_id, $pic_url])) {
+            respond(true, null, 'Profile created successfully.');
+        } else {
+            respond(false, null, 'Failed to create profile.');
+        }
+    }
 } elseif ($_SERVER['REQUEST_METHOD'] === 'GET' && $action === 'list_all' && $role === 'brand') {
     $category = $_GET['category'] ?? null;
     $sql = 'SELECT i.id, i.username, i.email, i.badge_level, i.category, i.followers_count, SUM(m.reach) as reach, SUM(m.engagement_total) as engagement FROM influencers i LEFT JOIN content_submissions cs ON cs.influencer_id = i.id LEFT JOIN metrics m ON m.submission_id = cs.id';

--- a/imx/dashboard.php
+++ b/imx/dashboard.php
@@ -1,5 +1,7 @@
 <?php
-session_start();
+require_once __DIR__ . '/includes/security.php';
+secure_session_start();
+secure_page_headers();
 ?>
 <!DOCTYPE html>
 <html lang="en">

--- a/imx/includes/instagram_api.php
+++ b/imx/includes/instagram_api.php
@@ -1,35 +1,42 @@
 <?php
-function instagram_get_profile($token) {
-    $url = 'https://graph.instagram.com/me?fields=id,username,followers_count,media_count,profile_picture_url&access_token=' . urlencode($token);
+function instagram_cached_request(string $url, int $ttl = 3600) {
+    $cacheDir = __DIR__ . '/../cache/';
+    if (!is_dir($cacheDir)) {
+        mkdir($cacheDir, 0755, true);
+    }
+    $hash = md5($url);
+    $file = $cacheDir . $hash . '.json';
+    if (file_exists($file) && (time() - filemtime($file)) < $ttl) {
+        return json_decode(file_get_contents($file), true);
+    }
+
     $ch = curl_init($url);
     curl_setopt_array($ch, [
         CURLOPT_RETURNTRANSFER => true,
         CURLOPT_TIMEOUT => 10,
     ]);
     $resp = curl_exec($ch);
-    if (curl_errno($ch)) {
-        curl_close($ch);
-        return null;
+    if (!curl_errno($ch)) {
+        file_put_contents($file, $resp);
     }
     curl_close($ch);
-    $data = json_decode($resp, true);
+    return json_decode($resp, true);
+}
+
+function instagram_get_profile($token) {
+    $url = 'https://graph.instagram.com/me?fields=id,username,followers_count,media_count,profile_picture_url&access_token=' . urlencode($token);
+    $data = instagram_cached_request($url, 3600);
     return $data ?? null;
 }
 
 function instagram_get_insights($igUserId, $token) {
     $metrics = 'impressions,reach,profile_views,website_clicks,follower_count';
     $url = 'https://graph.facebook.com/v18.0/' . urlencode($igUserId) . '/insights?metric=' . $metrics . '&period=lifetime&access_token=' . urlencode($token);
-    $ch = curl_init($url);
-    curl_setopt_array($ch, [
-        CURLOPT_RETURNTRANSFER => true,
-        CURLOPT_TIMEOUT => 10,
-    ]);
-    $resp = curl_exec($ch);
-    if (curl_errno($ch)) {
-        curl_close($ch);
-        return null;
-    }
-    curl_close($ch);
-    return json_decode($resp, true);
+    return instagram_cached_request($url, 3600);
+}
+
+function instagram_get_top_media($igUserId, $token) {
+    $url = 'https://graph.facebook.com/v18.0/' . urlencode($igUserId) . '/media?fields=id,caption,media_url,like_count,comments_count,timestamp&limit=5&access_token=' . urlencode($token);
+    return instagram_cached_request($url, 600);
 }
 ?>

--- a/imx/includes/security.php
+++ b/imx/includes/security.php
@@ -1,6 +1,16 @@
 <?php
 require_once __DIR__ . '/csrf.php';
 
+function secure_session_start(): void {
+    if (session_status() === PHP_SESSION_NONE) {
+        session_set_cookie_params([
+            'httponly' => true,
+            'samesite' => 'Lax'
+        ]);
+        session_start();
+    }
+}
+
 function require_csrf(): void {
     $token = $_SERVER['HTTP_X_CSRF_TOKEN'] ?? ($_POST['csrf_token'] ?? null);
     if (!verify_csrf_token($token)) {
@@ -22,4 +32,10 @@ function validate_upload(array $file, array $allowedTypes, int $maxSize = 524288
     $mime = finfo_file($finfo, $file['tmp_name']);
     finfo_close($finfo);
     return in_array($mime, $allowedTypes, true);
+}
+
+function secure_page_headers(): void {
+    header('X-Content-Type-Options: nosniff');
+    header('X-Frame-Options: SAMEORIGIN');
+    header("Content-Security-Policy: default-src 'self'; img-src 'self' data:");
 }

--- a/imx/pages/dm.php
+++ b/imx/pages/dm.php
@@ -1,5 +1,6 @@
 <?php
-session_start();
+require_once __DIR__ . '/../includes/security.php';
+secure_session_start();
 if(!isset($_SESSION['user_id'])){header('Location: login.html');exit;}
 ?>
 <!DOCTYPE html>

--- a/imx/pages/feed.php
+++ b/imx/pages/feed.php
@@ -1,5 +1,6 @@
 <?php
-session_start();
+require_once __DIR__ . '/../includes/security.php';
+secure_session_start();
 $role = $_SESSION['role'] ?? 'guest';
 ?>
 <!DOCTYPE html>

--- a/imx/pages/login.html
+++ b/imx/pages/login.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' data:">
     <title>Login</title>
     <link rel="stylesheet" href="../css/login-style.css">
     <link rel="stylesheet" href="../css/instagram-theme.css">
@@ -59,6 +60,9 @@
             <h2>Register as Brand</h2>
             <form id="brand-register-form">
                 <input type="email" id="brand-register-email" placeholder="Email" required style="width:100%; margin:8px 0; padding:8px; box-sizing:border-box;" />
+                <input type="text" id="brand-register-company" placeholder="Company Name" required style="width:100%; margin:8px 0; padding:8px; box-sizing:border-box;" />
+                <input type="url" id="brand-register-website" placeholder="Website" required style="width:100%; margin:8px 0; padding:8px; box-sizing:border-box;" />
+                <input type="text" id="brand-register-industry" placeholder="Industry" required style="width:100%; margin:8px 0; padding:8px; box-sizing:border-box;" />
                 <input type="password" id="brand-register-password" placeholder="Password" required style="width:100%; margin:8px 0; padding:8px; box-sizing:border-box;" />
                 <input type="password" id="brand-register-password-confirm" placeholder="Confirm Password" required style="width:100%; margin:8px 0; padding:8px; box-sizing:border-box;" />
                 <input type="hidden" id="csrf_brand" name="csrf_token" />
@@ -74,6 +78,8 @@
             <h2>Register as Influencer</h2>
             <form id="influencer-register-form">
                 <input type="email" id="influencer-register-email" placeholder="Email" required style="width:100%; margin:8px 0; padding:8px; box-sizing:border-box;" />
+                <input type="text" id="influencer-register-handle" placeholder="Instagram Handle" required style="width:100%; margin:8px 0; padding:8px; box-sizing:border-box;" />
+                <input type="text" id="influencer-register-category" placeholder="Category" required style="width:100%; margin:8px 0; padding:8px; box-sizing:border-box;" />
                 <input type="password" id="influencer-register-password" placeholder="Password" required style="width:100%; margin:8px 0; padding:8px; box-sizing:border-box;" />
                 <input type="password" id="influencer-register-password-confirm" placeholder="Confirm Password" required style="width:100%; margin:8px 0; padding:8px; box-sizing:border-box;" />
                 <input type="hidden" id="csrf_influencer" name="csrf_token" />
@@ -174,6 +180,9 @@
         document.getElementById('brand-register-form').addEventListener('submit', async function(e) {
             e.preventDefault();
             const email = document.getElementById('brand-register-email').value;
+            const company = document.getElementById('brand-register-company').value;
+            const website = document.getElementById('brand-register-website').value;
+            const industry = document.getElementById('brand-register-industry').value;
             const password = document.getElementById('brand-register-password').value;
             const passwordConfirm = document.getElementById('brand-register-password-confirm').value;
 
@@ -190,6 +199,9 @@
                     email: email,
                     password: password,
                     role: 'brand',
+                    company_name: company,
+                    website: website,
+                    industry: industry,
                     csrf_token: csrfToken
                 })
             });
@@ -204,6 +216,8 @@
         document.getElementById('influencer-register-form').addEventListener('submit', async function(e) {
             e.preventDefault();
             const email = document.getElementById('influencer-register-email').value;
+            const handle = document.getElementById('influencer-register-handle').value;
+            const category = document.getElementById('influencer-register-category').value;
             const password = document.getElementById('influencer-register-password').value;
             const passwordConfirm = document.getElementById('influencer-register-password-confirm').value;
 
@@ -220,6 +234,8 @@
                     email: email,
                     password: password,
                     role: 'influencer',
+                    instagram_handle: handle,
+                    category: category,
                     csrf_token: csrfToken
                 })
             });

--- a/imx/pages/onboarding.php
+++ b/imx/pages/onboarding.php
@@ -1,5 +1,6 @@
 <?php
-session_start();
+require_once __DIR__ . '/../includes/security.php';
+secure_session_start();
 if (!isset($_SESSION['user_id'])) {
     header('Location: login.html');
     exit;

--- a/imx/pages/profile-edit.php
+++ b/imx/pages/profile-edit.php
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Edit Profile</title>
+    <link rel="stylesheet" href="/../css/dashboard-style.css" />
+    <link rel="stylesheet" href="/../css/instagram-theme.css" />
+    <link rel="stylesheet" href="/../css/dark-theme.css" />
+</head>
+<body>
+<header class="top-bar">
+    <div class="logo">Glimmio</div>
+    <div id="page-title">Edit Profile</div>
+    <div class="top-icons"><a href="../dashboard.php">🏠</a></div>
+</header>
+<form id="edit-form" style="padding:20px;max-width:400px;margin:0 auto;" enctype="multipart/form-data">
+    <input type="text" name="username" id="username" placeholder="Username" />
+    <input type="text" name="category" id="category" placeholder="Category" />
+    <textarea name="bio" id="bio" placeholder="Bio" rows="4"></textarea>
+    <input type="text" name="upi_id" id="upi" placeholder="UPI ID" />
+    <input type="file" name="profile_pic" id="profile_pic" />
+    <input type="hidden" name="csrf_token" id="csrf_token" />
+    <button type="submit">Save</button>
+</form>
+<script>
+const role = '<?php echo $_SESSION["role"] ?? ""; ?>';
+fetch('/backend/auth.php?action=csrf').then(r=>r.json()).then(d=>{
+    document.getElementById('csrf_token').value=d.token;
+});
+
+document.getElementById('edit-form').addEventListener('submit', async e => {
+    e.preventDefault();
+    const fd = new FormData(e.target);
+    const res = await fetch('/backend/'+(role==='brand'?'brand':'influencer')+'.php?action=update_profile', {
+        method: 'POST',
+        body: fd
+    });
+    const data = await res.json();
+    alert(data.message);
+    if(data.success){ window.location.href = '../profile.php'; }
+});
+</script>
+</body>
+</html>

--- a/imx/profile.php
+++ b/imx/profile.php
@@ -1,5 +1,8 @@
 <?php
-session_start();
+$include = __DIR__ . '/includes/security.php';
+require_once $include;
+secure_session_start();
+secure_page_headers();
 if(!isset($_SESSION['user_id'])){header('Location: login.html');exit;}
 $role=$_SESSION['role'];
 ?>
@@ -24,12 +27,16 @@ $role=$_SESSION['role'];
         <img id="profile-pic" src="" alt="" style="width:100px;height:100px;border-radius:50%;object-fit:cover;background:#ddd;" />
         <h2 id="username" style="margin:10px 0 5px;font-size:22px;"></h2>
         <p id="stats" style="color:#666;"></p>
+        <p><a href="pages/profile-edit.php">Edit Profile</a></p>
     </div>
     <div id="profile-grid" class="feed-grid"></div>
+    <h3>Top Instagram Posts</h3>
+    <div id="top-media-grid" class="feed-grid"></div>
 </div>
 <script>
 const role='<?php echo $role;?>';
 let posts=[];
+let topMedia=[];
 async function loadProfile(){
     const resp=await fetch('/backend/'+(role==='brand'?'brand':'influencer')+'.php?action=profile');
     const data=await resp.json();
@@ -39,6 +46,7 @@ async function loadProfile(){
         document.getElementById('profile-pic').src=p.profile_pic||p.logo_url||'';
         document.getElementById('stats').textContent=`Followers ${p.followers_count||0} • Posts ${p.media_count||0}`;
         loadPosts(p.id);
+        if(role==='influencer') loadTopMedia();
     }
 }
 async function loadPosts(uid){
@@ -71,6 +79,27 @@ function renderPosts(){
     });
 }
 document.addEventListener('DOMContentLoaded',loadProfile);
+
+async function loadTopMedia(){
+    const res = await fetch('/backend/influencer.php?action=top_media');
+    const data = await res.json();
+    if(data.success){
+        topMedia = data.data.data || [];
+    }
+    renderTopMedia();
+}
+
+function renderTopMedia(){
+    const grid = document.getElementById('top-media-grid');
+    if(!grid) return;
+    grid.innerHTML='';
+    topMedia.forEach(m=>{
+        const card=document.createElement('div');
+        card.className='feed-card';
+        card.innerHTML=`<div class="media"><img src="${m.media_url}"/></div>`;
+        grid.appendChild(card);
+    });
+}
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- cache Instagram API calls to reduce requests
- expose `/backend/influencer.php?action=top_media` for top posts
- display top Instagram posts on profile page
- add security headers helper and apply on dashboard & profile
- secure login page with CSP meta tag

## Testing
- `composer install` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cca6f2cbc832898152de2e9f89938